### PR TITLE
⚡ Memoize FinanceContext Provider Value

### DIFF
--- a/src/contexts/FinanceContext.tsx
+++ b/src/contexts/FinanceContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, ReactNode } from 'react';
+import { createContext, useContext, ReactNode, useMemo } from 'react';
 import { useFinanceData } from '@/hooks/useFinanceData';
 
 type FinanceContextType = ReturnType<typeof useFinanceData>;
@@ -7,9 +7,31 @@ const FinanceContext = createContext<FinanceContextType | null>(null);
 
 export function FinanceProvider({ children }: { children: ReactNode }) {
   const financeData = useFinanceData();
+
+  const value = useMemo(() => financeData, [
+    financeData.transactions,
+    financeData.categories,
+    financeData.cards,
+    financeData.addTransaction,
+    financeData.deleteTransaction,
+    financeData.addCategory,
+    financeData.updateCategory,
+    financeData.deleteCategory,
+    financeData.addCard,
+    financeData.updateCard,
+    financeData.deleteCard,
+    financeData.balance,
+    financeData.getCardDebt,
+    financeData.totalCreditDebt,
+    financeData.creditCardsWithDebt,
+    financeData.getCategoryById,
+    financeData.getCardById,
+    financeData.exportData,
+    financeData.importData,
+  ]);
   
   return (
-    <FinanceContext.Provider value={financeData}>
+    <FinanceContext.Provider value={value}>
       {children}
     </FinanceContext.Provider>
   );


### PR DESCRIPTION
💡 **What:** Wrapped the `FinanceContext.Provider` value in `useMemo`.
🎯 **Why:** To prevent unnecessary re-renders of consumer components when `FinanceProvider` re-renders but the underlying data remains unchanged.
📊 **Measured Improvement:** Verified with a performance test that consumers now render only once instead of twice when the provider re-renders without data changes. The test was deleted after verification as per instructions.

---
*PR created automatically by Jules for task [2564473155708077116](https://jules.google.com/task/2564473155708077116) started by @imLeGEnDco55*